### PR TITLE
Use $::env(HOME) for the config file in Windows

### DIFF
--- a/src/gui.tcl
+++ b/src/gui.tcl
@@ -51,7 +51,6 @@ if { [info exists ::env(HOME) ] } {
 # prefix for starting a command in a window
 if { $tcl_platform(platform) == "windows" } {
     set WINPREFIX "cmd.exe /c start \"Propeller Output %p\""
-    set CONFIGDIR $ROOTDIR
 } elseif { [tk windowingsystem] == "aqua" } {
     set WINPREFIX $ROOTDIR/bin/mac_terminal.sh
 } elseif { [file executable /etc/alternatives/x-terminal-emulator] } {


### PR DESCRIPTION
A recent [change](https://github.com/totalspectrum/flexprop/commit/9fafdcfe04ce02175a1dc83487c2bb35e1763eca) made $::env(HOME) the location for the config file on Linux and Mac, but not on Windows.

However I can't think of a reason why, on Windows, the config file would need to be kept in the directory where the ZIP file was expanded, and why it couldn't go into the user's home directory, just like on other platforms. And keeping the configuration file in the home directory has the side effect that users don't have to remember to copy the .flexprop.conf file from the old directory to the new directory when they upgrade from one version of FlexProp to the next.

This one-liner removes the TCL instruction that sets CONFIGDIR back to $ROOTDIR on Windows, so that the config is saved in the user's home directory (usually C:\Users\\_username_). The change only affects Windows.

Thanks for considering!