### PR TITLE
Add RPM SPEC files to build RPMs for Fedora (and other RH OSes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ WIN_BINARIES=$(EXEBINFILES) bin/proploader.exe bin/proploader.mac
 #WIN_BINARIES=$(EXEBINFILES) bin/proploader.exe
 NATIVE_BINARIES=bin/flexspin bin/flexcc bin/loadp2 bin/proploader
 
+build: flexprop_base flexprop.bin $(NATIVE_BINARIES)
+
 install: check_dir flexprop_base flexprop.bin $(NATIVE_BINARIES)
 	mkdir -p $(INSTALL)
 	mkdir -p flexprop/bin
@@ -63,6 +65,12 @@ install: check_dir flexprop_base flexprop.bin $(NATIVE_BINARIES)
 	cp -r flexprop/* $(INSTALL)
 	cp -rp flexprop.bin $(INSTALL)/flexprop
 	cp -rp tcl_library $(INSTALL)/
+
+list_install: build
+	find $(NATIVE_BINARIES) -print
+	find flexprop/ -print
+	find flexprop.bin -print
+	find tcl_library -print
 
 check_dir:
 	if test -f $(INSTALL)/Makefile; then echo "ERROR: Install directory contains a Makefile (possibly installing to original source)"; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ NATIVE_BINARIES=bin/flexspin bin/flexcc bin/loadp2 bin/proploader
 
 build: flexprop_base flexprop.bin $(NATIVE_BINARIES)
 
-install: check_dir flexprop_base flexprop.bin $(NATIVE_BINARIES)
+install: check_dir build
 	mkdir -p $(INSTALL)
 	mkdir -p flexprop/bin
 	cp -r $(NATIVE_BINARIES) flexprop/bin
@@ -65,12 +65,6 @@ install: check_dir flexprop_base flexprop.bin $(NATIVE_BINARIES)
 	cp -r flexprop/* $(INSTALL)
 	cp -rp flexprop.bin $(INSTALL)/flexprop
 	cp -rp tcl_library $(INSTALL)/
-
-list_install: build
-	find $(NATIVE_BINARIES) -print
-	find flexprop/ -print
-	find flexprop.bin -print
-	find tcl_library -print
 
 check_dir:
 	if test -f $(INSTALL)/Makefile; then echo "ERROR: Install directory contains a Makefile (possibly installing to original source)"; exit 1; fi

--- a/SPECS/flexprop.sh
+++ b/SPECS/flexprop.sh
@@ -1,0 +1,4 @@
+# shellcheck shell=sh
+
+# Set system-wide path to flexprop
+export PATH=${PATH}:/opt/flexprop/

--- a/SPECS/flexprop.spec
+++ b/SPECS/flexprop.spec
@@ -7,13 +7,13 @@ Release: 1%{?dist}
 Summary: Flexprop GUI for Parallax Propeller development
 License: MIT        
 URL: https://github.com/%{orgname}/%{name}
-Source0: https://github.com/%{orgname}/%{name}/archive/refs/heads/master.tar.gz
+Source0: https://github.com/%{orgname}/%{name}/archive/refs/heads/%{branch}.tar.gz
 
 BuildRequires: gcc-c++ tk-devel texlive-latex pandoc libXScrnSaver-devel
 Requires: bzip2-libs fontconfig freetype glib2 glibc graphite2 harfbuzz libbrotli libpng libX11 libXau libxcb libXext libXft libxml2 libXrender libXScrnSaver pcre tcl tk xz-libs zlib libgcc libstdc++
 
 %description
-FlexProp is a GUI for Parallax Propeller development. It is a cross-platform
+FlexProp is a GUI for Parallax Propeller development.
 
 # TODO: It would be ideal if we could use spectool with a tarball, but with recursive
 # submodules, it doesn't work
@@ -52,7 +52,7 @@ cd %{name}
 %{_docdir}/%{name}/README.md
 %{_datadir}/%{name}/
 %{install_path}/%{name}/
-%{_sysconfdir}/profile.d/
+%{_sysconfdir}/profile.d/flexprop.sh
 
 
 %changelog

--- a/SPECS/flexprop.spec
+++ b/SPECS/flexprop.spec
@@ -1,0 +1,60 @@
+%define orgname drwonky
+%define branch rpm_spec
+Name: flexprop
+Version: 6.1.5
+Release: 1%{?dist}
+Summary: Flexprop GUI for Parallax Propeller development
+License: MIT        
+URL: https://github.com/%{orgname}/%{name}
+Source0: https://github.com/%{orgname}/%{name}/archive/refs/heads/master.tar.gz
+#URL: https://github.com/totalspectrum/flexprop
+#Source: https://github.com/totalspectrum/flexprop.git
+
+BuildRequires: gcc-c++ tk-devel texlive-latex pandoc libXScrnSaver-devel
+Requires: bzip2-libs fontconfig freetype glib2 glibc graphite2 harfbuzz libbrotli libpng libX11 libXau libxcb libXext libXft libxml2 libXrender libXScrnSaver pcre tcl tk xz-libs zlib libgcc libstdc++
+
+%description
+FlexProp is a GUI for Parallax Propeller development. It is a cross-platform
+
+
+%prep
+#%{__rm} -rf %{name}
+#%{__git} clone --recursive --depth 1 --branch %{branch} --single-branch %{url}
+
+
+%build
+cd %{name}
+%{__make} build
+
+
+%install
+%{__mkdir_p} %{buildroot}%{_datadir}/%{name}
+%{__mkdir_p} %{buildroot}%{_docdir}/%{name}
+%{__mkdir_p} %{buildroot}%{_bindir}/
+%{__install} -p -m 0644 %{_builddir}/%{name}/License.txt %{buildroot}%{_docdir}/%{name}
+%{__install} -p -m 0644 %{_builddir}/%{name}/README.md %{buildroot}%{_docdir}/%{name}
+%{__cp} -r %{_builddir}/%{name}/doc %{buildroot}%{_docdir}/%{name}/
+%{__install} -p -m 0755 %{_builddir}/%{name}/%{name}.bin %{buildroot}%{_bindir}/%{name}
+%{__install} -p -m 0755 %{_builddir}/%{name}/bin/* %{buildroot}%{_bindir}/
+%{__cp} -r %{_builddir}/%{name}/%{name}/include %{buildroot}%{_datadir}/%{name}/
+%{__cp} -r %{_builddir}/%{name}/%{name}/board %{buildroot}%{_datadir}/%{name}/
+%{__cp} -r %{_builddir}/%{name}/%{name}/samples %{buildroot}%{_datadir}/%{name}/
+%{__cp} -r %{_builddir}/%{name}/%{name}/src %{buildroot}%{_datadir}/%{name}/
+%{__cp} -r %{_builddir}/%{name}/tcl_library %{buildroot}%{_datadir}/%{name}/
+
+
+%files
+%license %{_docdir}/%{name}/License.txt
+%doc %{_docdir}/%{name}/doc/
+%{_docdir}/%{name}/README.md
+%{_datadir}/%{name}/
+%{_bindir}/%{name}
+%{_bindir}/flexcc
+%{_bindir}/flexspin
+%{_bindir}/loadp2
+%{_bindir}/proploader
+
+
+%changelog
+* Sat Jun 03 2023 Perry Harrington <pedward@apsoft.com>
+- Created spec file

--- a/SPECS/flexprop.spec
+++ b/SPECS/flexprop.spec
@@ -1,5 +1,5 @@
-%define orgname drwonky
-%define branch rpm_spec_opt
+%define orgname totalspectrum
+%define branch master
 %global install_path /opt
 Name: flexprop
 Version: 6.1.5
@@ -8,8 +8,6 @@ Summary: Flexprop GUI for Parallax Propeller development
 License: MIT        
 URL: https://github.com/%{orgname}/%{name}
 Source0: https://github.com/%{orgname}/%{name}/archive/refs/heads/master.tar.gz
-#URL: https://github.com/totalspectrum/flexprop
-#Source: https://github.com/totalspectrum/flexprop.git
 
 BuildRequires: gcc-c++ tk-devel texlive-latex pandoc libXScrnSaver-devel
 Requires: bzip2-libs fontconfig freetype glib2 glibc graphite2 harfbuzz libbrotli libpng libX11 libXau libxcb libXext libXft libxml2 libXrender libXScrnSaver pcre tcl tk xz-libs zlib libgcc libstdc++
@@ -17,12 +15,13 @@ Requires: bzip2-libs fontconfig freetype glib2 glibc graphite2 harfbuzz libbrotl
 %description
 FlexProp is a GUI for Parallax Propeller development. It is a cross-platform
 
-
+# TODO: It would be ideal if we could use spectool with a tarball, but with recursive
+# submodules, it doesn't work
 %prep
 %{__rm} -rf %{name}
 %{__git} clone --recursive --depth 1 --branch %{branch} --single-branch %{url}
 
-
+# We can't use %{make_build} because this won't compile with parallel Makes running
 %build
 cd %{name}
 %{__make} build
@@ -53,6 +52,7 @@ cd %{name}
 %{_docdir}/%{name}/README.md
 %{_datadir}/%{name}/
 %{install_path}/%{name}/
+%{_sysconfdir}/profile.d/
 
 
 %changelog

--- a/SPECS/flexprop.spec
+++ b/SPECS/flexprop.spec
@@ -1,5 +1,6 @@
 %define orgname drwonky
 %define branch rpm_spec
+%global install_path /opt
 Name: flexprop
 Version: 6.1.5
 Release: 1%{?dist}
@@ -18,8 +19,8 @@ FlexProp is a GUI for Parallax Propeller development. It is a cross-platform
 
 
 %prep
-#%{__rm} -rf %{name}
-#%{__git} clone --recursive --depth 1 --branch %{branch} --single-branch %{url}
+%{__rm} -rf %{name}
+%{__git} clone --recursive --depth 1 --branch %{branch} --single-branch %{url}
 
 
 %build
@@ -30,17 +31,18 @@ cd %{name}
 %install
 %{__mkdir_p} %{buildroot}%{_datadir}/%{name}
 %{__mkdir_p} %{buildroot}%{_docdir}/%{name}
-%{__mkdir_p} %{buildroot}%{_bindir}/
+%{__mkdir_p} %{buildroot}%{install_path}/%{name}/bin/
+%{__mkdir_p} %{buildroot}%{_bindir}
 %{__install} -p -m 0644 %{_builddir}/%{name}/License.txt %{buildroot}%{_docdir}/%{name}
 %{__install} -p -m 0644 %{_builddir}/%{name}/README.md %{buildroot}%{_docdir}/%{name}
 %{__cp} -r %{_builddir}/%{name}/doc %{buildroot}%{_docdir}/%{name}/
-%{__install} -p -m 0755 %{_builddir}/%{name}/%{name}.bin %{buildroot}%{_bindir}/%{name}
-%{__install} -p -m 0755 %{_builddir}/%{name}/bin/* %{buildroot}%{_bindir}/
-%{__cp} -r %{_builddir}/%{name}/%{name}/include %{buildroot}%{_datadir}/%{name}/
-%{__cp} -r %{_builddir}/%{name}/%{name}/board %{buildroot}%{_datadir}/%{name}/
-%{__cp} -r %{_builddir}/%{name}/%{name}/samples %{buildroot}%{_datadir}/%{name}/
-%{__cp} -r %{_builddir}/%{name}/%{name}/src %{buildroot}%{_datadir}/%{name}/
-%{__cp} -r %{_builddir}/%{name}/tcl_library %{buildroot}%{_datadir}/%{name}/
+%{__install} -p -m 0755 %{_builddir}/%{name}/%{name}.bin %{buildroot}%{install_path}/%{name}/%{name}
+%{__install} -p -m 0755 %{_builddir}/%{name}/bin/* %{buildroot}%{install_path}/%{name}/bin/
+%{__cp} -r %{_builddir}/%{name}/%{name}/include %{buildroot}%{install_path}/%{name}/
+%{__cp} -r %{_builddir}/%{name}/%{name}/board %{buildroot}%{install_path}/%{name}/
+%{__cp} -r %{_builddir}/%{name}/%{name}/samples %{buildroot}%{install_path}/%{name}/
+%{__cp} -r %{_builddir}/%{name}/%{name}/src %{buildroot}%{install_path}/%{name}/
+%{__cp} -r %{_builddir}/%{name}/tcl_library %{buildroot}%{install_path}/%{name}/
 
 
 %files
@@ -48,11 +50,7 @@ cd %{name}
 %doc %{_docdir}/%{name}/doc/
 %{_docdir}/%{name}/README.md
 %{_datadir}/%{name}/
-%{_bindir}/%{name}
-%{_bindir}/flexcc
-%{_bindir}/flexspin
-%{_bindir}/loadp2
-%{_bindir}/proploader
+%{install_path}/%{name}/
 
 
 %changelog

--- a/SPECS/flexprop.spec
+++ b/SPECS/flexprop.spec
@@ -1,5 +1,5 @@
 %define orgname drwonky
-%define branch rpm_spec
+%define branch rpm_spec_opt
 %global install_path /opt
 Name: flexprop
 Version: 6.1.5
@@ -31,8 +31,10 @@ cd %{name}
 %install
 %{__mkdir_p} %{buildroot}%{_datadir}/%{name}
 %{__mkdir_p} %{buildroot}%{_docdir}/%{name}
+%{__mkdir_p} %{buildroot}%{_sysconfdir}/profile.d/
 %{__mkdir_p} %{buildroot}%{install_path}/%{name}/bin/
 %{__mkdir_p} %{buildroot}%{_bindir}
+%{__install} -p -m 0644 %{_builddir}/%{name}/SPECS/flexprop.sh %{buildroot}%{_sysconfdir}/profile.d/
 %{__install} -p -m 0644 %{_builddir}/%{name}/License.txt %{buildroot}%{_docdir}/%{name}
 %{__install} -p -m 0644 %{_builddir}/%{name}/README.md %{buildroot}%{_docdir}/%{name}
 %{__cp} -r %{_builddir}/%{name}/doc %{buildroot}%{_docdir}/%{name}/

--- a/src/flexprop_native.c
+++ b/src/flexprop_native.c
@@ -30,6 +30,11 @@
 extern Tcl_PackageInitProc Tktest_Init;
 #endif /* TK_TEST */
 
+/* define the system-wide LSN dir for install */
+#ifndef LSN_DIR
+#define LSN_DIR "/usr/share/flexprop"
+#endif
+
 /*
  * The following #if block allows you to change the AppInit function by using
  * a #define of TCL_LOCAL_APPINIT instead of rewriting this entire file. The
@@ -208,6 +213,20 @@ getProgramPath(char **argv, char *path, int size)
       path[r] = 0;
     else
       return -1;
+    
+    char *src_dir = dyn_strcat(path, "/src");
+    char *lsn_dir = dyn_strcat(LSN_DIR, "/src");
+
+    if (access(src_dir, F_OK) != 0) {
+        if (access(lsn_dir, F_OK) == 0) {
+            if (strlen(LSN_DIR) >= size)
+                return -1;
+            strncpy(path, LSN_DIR, size);
+        } else {
+            return -1;
+        }
+    }
+
 #elif defined(__OSX__)
     uint32_t bufsize = size - 1;
     int r = _NSGetExecutablePath(path, &bufsize);

--- a/src/flexprop_native.c
+++ b/src/flexprop_native.c
@@ -30,11 +30,6 @@
 extern Tcl_PackageInitProc Tktest_Init;
 #endif /* TK_TEST */
 
-/* define the system-wide LSN dir for install */
-#ifndef LSN_DIR
-#define LSN_DIR "/usr/share/flexprop"
-#endif
-
 /*
  * The following #if block allows you to change the AppInit function by using
  * a #define of TCL_LOCAL_APPINIT instead of rewriting this entire file. The
@@ -213,20 +208,6 @@ getProgramPath(char **argv, char *path, int size)
       path[r] = 0;
     else
       return -1;
-    
-    char *src_dir = dyn_strcat(path, "/src");
-    char *lsn_dir = dyn_strcat(LSN_DIR, "/src");
-
-    if (access(src_dir, F_OK) != 0) {
-        if (access(lsn_dir, F_OK) == 0) {
-            if (strlen(LSN_DIR) >= size)
-                return -1;
-            strncpy(path, LSN_DIR, size);
-        } else {
-            return -1;
-        }
-    }
-
 #elif defined(__OSX__)
     uint32_t bufsize = size - 1;
     int r = _NSGetExecutablePath(path, &bufsize);


### PR DESCRIPTION
This PR creates the necessary SPEC file for building an RPM that lives in `/opt` and `/usr/share/doc` (LSB paths where possible).  The path detection in flexprop doesn't work with LSB on Linux, simple fixes didn't result in a working build, so I just setup everything in `/opt/flexprop`.  There is a path file that goes in `/etc/profile.d` so it works like if it were in the system directories.  I have another branch with the LSB paths and some changes I made to detect whether it was running from a unified install or LSB.

The Makefile was updated to add a `build` target that does everything that `install` does, except install.